### PR TITLE
Added SSL TLS support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Caddy v2 API helper library.",
     "type": "library",
     "require": {
-        "guzzlehttp/guzzle": "^6.4"
+        "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "*",

--- a/src/Client.php
+++ b/src/Client.php
@@ -16,10 +16,14 @@ class Client
     /** @var array */
     public $curlOptions;
 
-    public function __construct(string $caddyHost = 'localhost:2019', array $headers = [])
+    /** @var boolean */
+    public $verify;
+
+    public function __construct(string $caddyHost = 'localhost:2019', array $headers = [], bool $verify = true, array $certs = [], array $curlOptions = [])
     {
         $this->setCaddyHost($caddyHost);
         $this->setHeaders($headers);
+        $this->setVerify($verify);
         $this->setCerts($certs);
         $this->setCurlOptions($curlOptions);
     }
@@ -49,7 +53,19 @@ class Client
     }
 
     /**
-     * Sets the headers.
+     * Sets the verify
+     *
+     * @param boolean $verify
+     * @return Client
+     */
+    public function setVerify(bool $verify = true)
+    {
+        $this->verify = $verify;
+        return $this;
+    }
+
+    /**
+     * Sets the certificates
      *
      * @param string $headers
      * @return Client
@@ -61,7 +77,7 @@ class Client
     }
 
     /**
-     * Sets the headers.
+     * Sets the curl options
      *
      * @param string $headers
      * @return Client
@@ -79,6 +95,6 @@ class Client
      */
     public function request(): Request
     {
-        return new Request($this->caddyHost, $this->headers, $this->certs, $this->curlOptions);
+        return new Request($this->caddyHost, $this->headers, $this->verify, $this->certs, $this->curlOptions);
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,10 +10,18 @@ class Client
     /** @var array */
     public $headers;
 
+    /** @var array */
+    public $certs;
+
+    /** @var array */
+    public $curlOptions;
+
     public function __construct(string $caddyHost = 'localhost:2019', array $headers = [])
     {
         $this->setCaddyHost($caddyHost);
         $this->setHeaders($headers);
+        $this->setCerts($certs);
+        $this->setCurlOptions($curlOptions);
     }
 
     /**
@@ -41,12 +49,36 @@ class Client
     }
 
     /**
+     * Sets the headers.
+     *
+     * @param string $headers
+     * @return Client
+     */
+    public function setCerts(array $certs = [])
+    {
+        $this->certs = $certs;
+        return $this;
+    }
+
+    /**
+     * Sets the headers.
+     *
+     * @param string $headers
+     * @return Client
+     */
+    public function setCurlOptions(array $curlOptions = [])
+    {
+        $this->curlOptions = $curlOptions;
+        return $this;
+    }
+
+    /**
      * Creates a new Request instance.
      *
      * @return Request
      */
     public function request(): Request
     {
-        return new Request($this->caddyHost, $this->headers);
+        return new Request($this->caddyHost, $this->headers, $this->certs, $this->curlOptions);
     }
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -12,15 +12,18 @@ class Request
     /** @var string */
     public $uri = '/config';
 
-    public function __construct(string $caddyHost, array $headers = [])
+    public function __construct(string $caddyHost, array $headers = [], array $certs = [], array $curlOptions = [])
     {
         $this->http = new Client([
             'base_uri' => $caddyHost
         ]);
 
         $this->options = [
+            'cert' => $certs->public,
+            'ssl_key' => $certs->key,
             'http_errors' => false,
-            'headers'     => $headers
+            'headers'     => $headers,
+            'curl.options' => $curlOptions,
         ];
     }
 

--- a/src/Request.php
+++ b/src/Request.php
@@ -12,15 +12,16 @@ class Request
     /** @var string */
     public $uri = '/config';
 
-    public function __construct(string $caddyHost, array $headers = [], array $certs = [], array $curlOptions = [])
+    public function __construct(string $caddyHost, array $headers = [], bool $verify = true, array $certs = [], array $curlOptions = [])
     {
         $this->http = new Client([
+            'verify' => $verify,
             'base_uri' => $caddyHost
         ]);
 
         $this->options = [
-            'cert' => $certs->public,
-            'ssl_key' => $certs->key,
+            'cert' => $certs['public'],
+            'ssl_key' => $certs['key'],
             'http_errors' => false,
             'headers'     => $headers,
             'curl.options' => $curlOptions,


### PR DESCRIPTION
Caddy supports access controls for the admin API through public/private TLS certificate authentication. Guzzle has the ability to facilitate this so it was just a matter of adjusting the Client and Request class to accommodate the public/private certificates as well as the option to ignore invalid SSL certificate errors (if you are self-signing)